### PR TITLE
fix crash on api21 by Java 8 library desugaring in D8 and R8

### DIFF
--- a/app/autodiscovery/api/build.gradle
+++ b/app/autodiscovery/api/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:core")
 }
@@ -22,6 +23,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/autodiscovery/providersxml/build.gradle
+++ b/app/autodiscovery/providersxml/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:core")
     implementation project(":mail:common")
@@ -36,6 +37,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/autodiscovery/srvrecords/build.gradle
+++ b/app/autodiscovery/srvrecords/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:core")
     implementation project(":mail:common")
@@ -37,6 +38,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/autodiscovery/thunderbird/build.gradle
+++ b/app/autodiscovery/thunderbird/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:core")
     implementation project(":mail:common")
@@ -37,6 +38,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":mail:common")
     api project(":backend:api")
@@ -55,6 +56,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/crypto-openpgp/build.gradle
+++ b/app/crypto-openpgp/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:core")
 
@@ -24,6 +25,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/k9mail-jmap/build.gradle
+++ b/app/k9mail-jmap/build.gradle
@@ -8,6 +8,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:ui:legacy")
     implementation project(":app:core")
@@ -104,6 +105,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -7,6 +7,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:ui:legacy")
     implementation project(":app:core")
@@ -118,6 +119,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/storage/build.gradle
+++ b/app/storage/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api "org.koin:koin-core:${versions.koin}"
 
@@ -39,6 +40,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/testing/build.gradle
+++ b/app/testing/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(':app:core')
 
@@ -28,6 +29,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/ui/base/build.gradle
+++ b/app/ui/base/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation project(":app:core")
 
@@ -30,6 +31,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/ui/legacy/build.gradle
+++ b/app/ui/legacy/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":app:ui:base")
     debugImplementation project(":app:ui:setup")
@@ -91,6 +92,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/app/ui/setup/build.gradle
+++ b/app/ui/setup/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":app:ui:base")
     implementation project(":app:core")
@@ -43,6 +44,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(":mail:common")
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 }
@@ -21,6 +22,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/backend/imap/build.gradle
+++ b/backend/imap/build.gradle
@@ -7,6 +7,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":backend:api")
     api project(":mail:protocols:imap")
@@ -39,6 +40,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/backend/jmap/build.gradle
+++ b/backend/jmap/build.gradle
@@ -8,6 +8,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":backend:api")
 
@@ -42,6 +43,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/backend/pop3/build.gradle
+++ b/backend/pop3/build.gradle
@@ -7,6 +7,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":backend:api")
     api project(":mail:protocols:pop3")
@@ -39,6 +40,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/backend/webdav/build.gradle
+++ b/backend/webdav/build.gradle
@@ -7,6 +7,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":backend:api")
     api project(":mail:protocols:webdav")
@@ -38,6 +39,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
                 'fastAdapter': '5.4.0',
                 'preferencesFix': '1.1.0',
                 'okio': '2.9.0',
+                'desugar_jdk_libs': '1.0.5',
                 'moshi': '1.11.0',
                 'timber': '4.7.1',
                 'koin': '2.1.6',

--- a/mail/common/build.gradle
+++ b/mail/common/build.gradle
@@ -7,6 +7,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation "org.apache.james:apache-mime4j-core:${versions.mime4j}"
     implementation "org.apache.james:apache-mime4j-dom:${versions.mime4j}"
@@ -45,6 +46,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/mail/protocols/imap/build.gradle
+++ b/mail/protocols/imap/build.gradle
@@ -7,6 +7,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":mail:common")
 
@@ -46,6 +47,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/mail/protocols/pop3/build.gradle
+++ b/mail/protocols/pop3/build.gradle
@@ -6,6 +6,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     api project(":mail:common")
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "androidx.annotation:annotation:${versions.androidxAnnotation}"
@@ -40,6 +41,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/mail/protocols/smtp/build.gradle
+++ b/mail/protocols/smtp/build.gradle
@@ -6,6 +6,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     api project(":mail:common")
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
@@ -40,6 +41,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/mail/protocols/webdav/build.gradle
+++ b/mail/protocols/webdav/build.gradle
@@ -6,6 +6,7 @@ if (rootProject.testCoverage) {
 
 dependencies {
     api project(":mail:common")
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
@@ -45,6 +46,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }

--- a/mail/testing/build.gradle
+++ b/mail/testing/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:${versions.desugar_jdk_libs}"
 
     api project(":mail:common")
 
@@ -24,6 +25,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }


### PR DESCRIPTION
https://developer.android.com/studio/releases/gradle-plugin#j8-library-desugaring

Please ensure that your pull request meets the following requirements - thanks!

* Does not contain merge commits. Rebase instead.
* Contains commits with descriptive titles.
* New code is written in Kotlin whenever possible.
* Follows our existing codestyle (`gradlew ktlintCheck`; will be checked by CI).
* Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
* Uses a descriptive title; don't put issue numbers in there.
* Contains a reference to the issue that it fixes (e.g. *Closes #XXX* or *Fixes #XXX*) in the body text.
* For cosmetic changes add one or multiple images, if possible.

Finally, please replace this template text with a description of the change and additional context if necessary.
