### PR TITLE
Rewrite custom app language feature

### DIFF
--- a/app/k9mail/src/main/java/com/fsck/k9/App.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/App.kt
@@ -1,16 +1,29 @@
 package com.fsck.k9
 
 import android.app.Application
+import android.content.res.Configuration
 import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.external.MessageProvider
+import com.fsck.k9.ui.base.AppLanguageManager
 import com.fsck.k9.ui.base.ThemeManager
+import com.fsck.k9.ui.base.extensions.currentLocale
+import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.plus
 import org.koin.android.ext.android.inject
 
 class App : Application() {
     private val messagingController: MessagingController by inject()
     private val messagingListenerProvider: MessagingListenerProvider by inject()
     private val themeManager: ThemeManager by inject()
+    private val appLanguageManager: AppLanguageManager by inject()
+    private val appCoroutineScope: CoroutineScope = GlobalScope + Dispatchers.Main
 
     override fun onCreate() {
         Core.earlyInit(this)
@@ -22,11 +35,48 @@ class App : Application() {
         K9.init(this)
         Core.init(this)
         MessageProvider.init()
+        initializeAppLanguage()
         themeManager.init()
 
         messagingListenerProvider.listeners.forEach { listener ->
             messagingController.addListener(listener)
         }
+    }
+
+    private fun initializeAppLanguage() {
+        appLanguageManager.init()
+        applyOverrideLocale()
+        listenForAppLanguageChanges()
+    }
+
+    private fun applyOverrideLocale() {
+        appLanguageManager.getOverrideLocale()?.let { overrideLocale ->
+            updateConfigurationWithLocale(resources.configuration, overrideLocale)
+        }
+    }
+
+    private fun listenForAppLanguageChanges() {
+        appLanguageManager.overrideLocale
+            .drop(1) // We already applied the initial value
+            .onEach { overrideLocale ->
+                val locale = overrideLocale ?: Locale.getDefault()
+                updateConfigurationWithLocale(resources.configuration, locale)
+            }
+            .launchIn(appCoroutineScope)
+    }
+
+    override fun onConfigurationChanged(newConfiguration: Configuration) {
+        applyOverrideLocale()
+        super.onConfigurationChanged(resources.configuration)
+    }
+
+    private fun updateConfigurationWithLocale(configuration: Configuration, locale: Locale) {
+        val newConfiguration = Configuration(configuration).apply {
+            currentLocale = locale
+        }
+
+        @Suppress("DEPRECATION")
+        resources.updateConfiguration(newConfiguration, resources.displayMetrics)
     }
 
     companion object {

--- a/app/ui/base/build.gradle
+++ b/app/ui/base/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:${versions.androidxCore}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}"
 }
 
 android {

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/AppLanguageManager.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/AppLanguageManager.kt
@@ -1,0 +1,74 @@
+package com.fsck.k9.ui.base
+
+import android.content.res.Resources
+import com.fsck.k9.K9
+import com.fsck.k9.ui.base.extensions.currentLocale
+import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+
+/**
+ * Manages app language changes.
+ *
+ * - Sets the default locale when the app language is changed.
+ * - Notifies listeners when the app language has changed.
+ */
+class AppLanguageManager(
+    private val coroutineScope: CoroutineScope = GlobalScope + Dispatchers.Main
+) {
+    private var currentOverrideLocale: Locale? = null
+    private val _overrideLocale = MutableSharedFlow<Locale?>(replay = 1)
+    val overrideLocale: Flow<Locale?> = _overrideLocale
+
+    fun init() {
+        setLocale(K9.k9Language)
+    }
+
+    fun getOverrideLocale(): Locale? = currentOverrideLocale
+
+    fun getAppLanguage(): String {
+        return K9.k9Language
+    }
+
+    fun setAppLanguage(appLanguage: String) {
+        if (appLanguage == K9.k9Language) {
+            return
+        }
+
+        K9.k9Language = appLanguage
+
+        setLocale(appLanguage)
+    }
+
+    private fun setLocale(appLanguage: String) {
+        val overrideLocale = getOverrideLocaleForLanguage(appLanguage)
+        currentOverrideLocale = overrideLocale
+
+        val locale = overrideLocale ?: systemLocale
+        Locale.setDefault(locale)
+
+        coroutineScope.launch {
+            _overrideLocale.emit(overrideLocale)
+        }
+    }
+
+    private fun getOverrideLocaleForLanguage(appLanguage: String): Locale? {
+        return if (appLanguage.isEmpty()) {
+            null
+        } else if (appLanguage.length == 5 && appLanguage[2] == '_') {
+            // language is in the form: en_US
+            val language = appLanguage.substring(0, 2)
+            val country = appLanguage.substring(3)
+            Locale(language, country)
+        } else {
+            Locale(appLanguage)
+        }
+    }
+
+    private val systemLocale get() = Resources.getSystem().configuration.currentLocale
+}

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
@@ -1,12 +1,11 @@
 package com.fsck.k9.ui.base
 
-import android.content.res.Resources
+import android.content.Context
 import android.os.Bundle
-import android.text.TextUtils
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import com.fsck.k9.K9
+import androidx.lifecycle.asLiveData
 import java.util.Locale
 import org.koin.android.ext.android.inject
 
@@ -14,56 +13,41 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
     constructor() : this(ThemeType.DEFAULT)
 
     protected val themeManager: ThemeManager by inject()
+    private val appLanguageManager: AppLanguageManager by inject()
 
-    private lateinit var currentLanguage: String
-    private lateinit var currentTheme: Theme
+    private var overrideLocaleOnLaunch: Locale? = null
+
+    override fun attachBaseContext(baseContext: Context) {
+        overrideLocaleOnLaunch = appLanguageManager.getOverrideLocale()
+
+        val newBaseContext = overrideLocaleOnLaunch?.let { locale ->
+            LocaleContextWrapper(baseContext, locale)
+        } ?: baseContext
+
+        super.attachBaseContext(newBaseContext)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        initializeLanguage()
         initializeTheme()
         super.onCreate(savedInstanceState)
+
+        listenForAppLanguageChanges()
     }
 
-    override fun onResume() {
-        languageChangeCheck()
-        super.onResume()
-    }
-
-    private fun initializeLanguage() {
-        K9.k9Language.let { language ->
-            currentLanguage = language
-            setLanguage(language)
+    private fun listenForAppLanguageChanges() {
+        appLanguageManager.overrideLocale.asLiveData().observe(this) { overrideLocale ->
+            if (overrideLocale != overrideLocaleOnLaunch) {
+                recreate()
+            }
         }
     }
 
     private fun initializeTheme() {
-        currentTheme = themeManager.appTheme
         val theme = when (themeType) {
             ThemeType.DEFAULT -> themeManager.appThemeResourceId
             ThemeType.DIALOG -> themeManager.translucentDialogThemeResourceId
         }
         setTheme(theme)
-    }
-
-    private fun languageChangeCheck() {
-        if (currentLanguage != K9.k9Language) {
-            recreate()
-        }
-    }
-
-    private fun setLanguage(language: String) {
-        val locale = if (TextUtils.isEmpty(language)) {
-            Resources.getSystem().configuration.locale
-        } else if (language.length == 5 && language[2] == '_') {
-            // language is in the form: en_US
-            Locale(language.substring(0, 2), language.substring(3))
-        } else {
-            Locale(language)
-        }
-
-        val config = resources.configuration
-        config.locale = locale
-        resources.updateConfiguration(config, resources.displayMetrics)
     }
 
     protected fun setLayout(@LayoutRes layoutResId: Int) {

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/KoinModule.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/KoinModule.kt
@@ -4,4 +4,5 @@ import org.koin.dsl.module
 
 val uiBaseModule = module {
     single { ThemeManager(context = get(), themeProvider = get()) }
+    single { AppLanguageManager() }
 }

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/LocaleContextWrapper.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/LocaleContextWrapper.kt
@@ -1,0 +1,17 @@
+package com.fsck.k9.ui.base
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.res.Configuration
+import com.fsck.k9.ui.base.extensions.currentLocale
+import java.util.Locale
+
+/**
+ * In combination with `AppCompatActivity` this will override the locale in the configuration.
+ */
+internal class LocaleContextWrapper(baseContext: Context, private val locale: Locale) : ContextWrapper(baseContext) {
+    override fun createConfigurationContext(overrideConfiguration: Configuration): Context {
+        overrideConfiguration.currentLocale = locale
+        return super.createConfigurationContext(overrideConfiguration)
+    }
+}

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/extensions/ConfigurationExtensions.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/extensions/ConfigurationExtensions.kt
@@ -1,0 +1,41 @@
+package com.fsck.k9.ui.base.extensions
+
+import android.content.res.Configuration
+import android.os.Build
+import android.os.LocaleList
+import androidx.annotation.RequiresApi
+import java.util.Locale
+
+@Suppress("DEPRECATION")
+var Configuration.currentLocale: Locale
+    get() {
+        return if (Build.VERSION.SDK_INT >= 24) {
+            locales[0]
+        } else {
+            locale
+        }
+    }
+    set(value) {
+        if (Build.VERSION.SDK_INT >= 24) {
+            setLocales(createLocaleList(value, locales))
+        } else {
+            setLocale(value)
+        }
+    }
+
+@RequiresApi(24)
+private fun createLocaleList(topLocale: Locale, otherLocales: LocaleList): LocaleList {
+    if (!otherLocales.isEmpty && otherLocales[0] == topLocale) {
+        return otherLocales
+    }
+
+    val locales = mutableListOf(topLocale)
+    for (index in 0 until otherLocales.size()) {
+        val currentLocale = otherLocales[index]
+        if (currentLocale != topLocale) {
+            locales.add(currentLocale)
+        }
+    }
+
+    return LocaleList(*locales.toTypedArray())
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityAppearance.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityAppearance.kt
@@ -4,7 +4,6 @@ import com.fsck.k9.K9
 
 data class MessageListActivityAppearance(
     val appTheme: K9.AppTheme,
-    val k9Language: String,
     val isShowUnifiedInbox: Boolean,
     val isShowMessageListStars: Boolean,
     val isShowCorrespondentNames: Boolean,
@@ -35,7 +34,6 @@ data class MessageListActivityAppearance(
     companion object {
         fun create() = MessageListActivityAppearance(
             appTheme = K9.appTheme,
-            k9Language = K9.k9Language,
             isShowUnifiedInbox = K9.isShowUnifiedInbox,
             isShowMessageListStars = K9.isShowMessageListStars,
             isShowCorrespondentNames = K9.isShowCorrespondentNames,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -18,7 +18,7 @@ val settingsUiModule = module {
     single { AccountsLiveData(get()) }
     viewModel { SettingsViewModel(accountManager = get(), accounts = get()) }
 
-    factory { GeneralSettingsDataStore(jobManager = get(), themeManager = get()) }
+    factory { GeneralSettingsDataStore(jobManager = get(), themeManager = get(), appLanguageManager = get()) }
     single(named("SaveSettingsExecutorService")) {
         Executors.newSingleThreadExecutor(NamedThreadFactory("SaveSettings"))
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -1,18 +1,18 @@
 package com.fsck.k9.ui.settings.general
 
-import androidx.fragment.app.FragmentActivity
 import androidx.preference.PreferenceDataStore
 import com.fsck.k9.K9
 import com.fsck.k9.K9.AppTheme
 import com.fsck.k9.K9.SubTheme
 import com.fsck.k9.job.K9JobManager
+import com.fsck.k9.ui.base.AppLanguageManager
 import com.fsck.k9.ui.base.ThemeManager
 
 class GeneralSettingsDataStore(
     private val jobManager: K9JobManager,
-    private val themeManager: ThemeManager
+    private val themeManager: ThemeManager,
+    private val appLanguageManager: AppLanguageManager
 ) : PreferenceDataStore() {
-    var activity: FragmentActivity? = null
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean {
         return when (key) {
@@ -92,7 +92,7 @@ class GeneralSettingsDataStore(
 
     override fun getString(key: String, defValue: String?): String? {
         return when (key) {
-            "language" -> K9.k9Language
+            "language" -> appLanguageManager.getAppLanguage()
             "theme" -> appThemeToString(K9.appTheme)
             "message_compose_theme" -> subThemeToString(K9.messageComposeTheme)
             "messageViewTheme" -> subThemeToString(K9.messageViewTheme)
@@ -128,7 +128,7 @@ class GeneralSettingsDataStore(
         if (value == null) return
 
         when (key) {
-            "language" -> setLanguage(value)
+            "language" -> appLanguageManager.setAppLanguage(value)
             "theme" -> setTheme(value)
             "message_compose_theme" -> K9.messageComposeTheme = stringToSubTheme(value)
             "messageViewTheme" -> K9.messageViewTheme = stringToSubTheme(value)
@@ -234,11 +234,6 @@ class GeneralSettingsDataStore(
         themeManager.updateAppTheme()
     }
 
-    private fun setLanguage(language: String) {
-        K9.k9Language = language
-        recreateActivity()
-    }
-
     private fun appThemeToString(theme: AppTheme) = when (theme) {
         AppTheme.LIGHT -> "light"
         AppTheme.DARK -> "dark"
@@ -271,9 +266,5 @@ class GeneralSettingsDataStore(
             K9.backgroundOps = newBackgroundOps
             jobManager.scheduleAllMailJobs()
         }
-    }
-
-    private fun recreateActivity() {
-        activity?.recreate()
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -22,7 +22,6 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         activity?.title = preferenceScreen.title
-        dataStore.activity = activity
     }
 
     private fun initializeTheme() {


### PR DESCRIPTION
Add AppLanguageManager that notifies listeners when the app language has been changed. K9Activity uses this mechanism to restart() on language changes. The Application object will update its configuration.

Instead of using the deprecated Resources.updateConfiguration() we now use LocaleContextWrapper (in combination with AppCompat) to override the locale in the configuration.

Please ensure that your pull request meets the following requirements - thanks!

* Does not contain merge commits. Rebase instead.
* Contains commits with descriptive titles.
* New code is written in Kotlin whenever possible.
* Follows our existing codestyle (`gradlew ktlintCheck`; will be checked by CI).
* Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
* Uses a descriptive title; don't put issue numbers in there.
* Contains a reference to the issue that it fixes (e.g. *Closes #XXX* or *Fixes #XXX*) in the body text.
* For cosmetic changes add one or multiple images, if possible.

Finally, please replace this template text with a description of the change and additional context if necessary.
